### PR TITLE
add tty? method to Job model which acts as Capistrano::Logger

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -52,6 +52,11 @@ class Job < ActiveRecord::Base
     end
   end
 
+  # required for Capistrano v2.3.5
+  def tty?
+    nil
+  end
+  
 
   private
 
@@ -66,5 +71,5 @@ class Job < ActiveRecord::Base
     def execute_task
       CapExecute.perform_async id
     end
-
+    
 end


### PR DESCRIPTION
- actual for Capistrano since version 2.13.5

Собственно - вот https://github.com/capistrano/capistrano/blob/master/lib/capistrano/logger.rb#L86 
и вот https://github.com/express42/strano/blob/master/app/models/job.rb#L24
